### PR TITLE
Fix for blank strings in timeout config property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'java'
 
 gocdPlugin {
   id = 'com.thoughtworks.gocd.secretmanager.vault'
-  pluginVersion = '1.0.0'
+  pluginVersion = '1.0.1'
   goCdVersion = '19.6.0'
   name = 'Vault secret manager plugin'
   description = 'The plugin allows to use hashicorp vault as secret manager for the GoCD server'

--- a/src/main/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfig.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfig.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class SecretConfig {
     private static final Gson GSON = new GsonBuilder().
@@ -39,6 +40,8 @@ public class SecretConfig {
     public static final String CERT_AUTH_METHOD = "cert";
 
     public static final List<String> SUPPORTED_AUTH_METHODS = asList(TOKEN_AUTH_METHOD, APPROLE_AUTH_METHOD, CERT_AUTH_METHOD);
+    public static final int DEFAULT_CONNECTION_TIMEOUT = 5;
+    public static final int DEFAULT_READ_TIMEOUT = 30;
 
     @Expose
     @SerializedName("VaultUrl")
@@ -53,12 +56,12 @@ public class SecretConfig {
     @Expose
     @SerializedName("ConnectionTimeout")
     @Property(name = "ConnectionTimeout")
-    private Integer connectionTimeout = 5;
+    private String connectionTimeout;
 
     @Expose
     @SerializedName("ReadTimeout")
     @Property(name = "ReadTimeout")
-    private Integer readTimeout = 30;
+    private String readTimeout;
 
     @Expose
     @SerializedName("AuthMethod")
@@ -104,11 +107,17 @@ public class SecretConfig {
     }
 
     public Integer getConnectionTimeout() {
-        return connectionTimeout;
+        if (isBlank(connectionTimeout)) {
+            return DEFAULT_CONNECTION_TIMEOUT;
+        }
+        return Integer.valueOf(connectionTimeout);
     }
 
     public Integer getReadTimeout() {
-        return readTimeout;
+        if (isBlank(readTimeout)) {
+            return DEFAULT_READ_TIMEOUT;
+        }
+        return Integer.valueOf(readTimeout);
     }
 
     public String getAuthMethod() {
@@ -143,7 +152,7 @@ public class SecretConfig {
         return SUPPORTED_AUTH_METHODS.contains(authMethod.toLowerCase());
     }
 
-    public static SecretConfig fromJSON(Map<String, String>     request) {
+    public static SecretConfig fromJSON(Map<String, String> request) {
         String json = GsonTransformer.toJson(request);
         return GSON.fromJson(json, SecretConfig.class);
     }

--- a/src/test/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfigTest.java
+++ b/src/test/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfigTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.gocd.secretmanager.vault.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecretConfigTest {
+    @Test
+    void shouldReturnDefaultValueForTimeout() {
+        HashMap<String, String> request = new HashMap<>();
+        SecretConfig secretConfig = SecretConfig.fromJSON(request);
+        assertThat(secretConfig.getConnectionTimeout()).isEqualTo(5);
+        assertThat(secretConfig.getReadTimeout()).isEqualTo(30);
+    }
+
+    @Test
+    void shouldReturnTheValuesIfSet() {
+        HashMap<String, String> request = new HashMap<>();
+        request.put("ConnectionTimeout", "9");
+        request.put("ReadTimeout", "50");
+        SecretConfig secretConfig = SecretConfig.fromJSON(request);
+        assertThat(secretConfig.getConnectionTimeout()).isEqualTo(9);
+        assertThat(secretConfig.getReadTimeout()).isEqualTo(50);
+    }
+}


### PR DESCRIPTION
Related GoCD issue: https://github.com/gocd/gocd/issues/7157
 - if the timeout config property is received as null or empty string, default value will be set, else we will try to parse it into Integer