### PR TITLE
Adding the MaxRetries and RetryIntervalMilliseconds config for Vault Auth Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Alternatively, the configuration can be added directly to the config.xml using t
 | SecretId          | No       |  Required if using `approle` auth method. |
 | ClientKeyPem      | No       |  Required if using `cert` auth method. An RSA private key, in unencrypted PEM format with UTF-8 encoding. |
 | ClientPem         | No       |  Required if using `cert` auth method. An X.509 client certificate, in unencrypted PEM format with UTF-8 encoding. |
+| Max Retries       | No       | Number of times to attempt to gather secrets from Vault. Defaults to `0`. |
+| Retry Interval Milliseconds | No       | Duration between retry attempts (set by `Max Retries`). Defaults to `100 milliseconds`. |
 
 
 ### Building the code base

--- a/src/main/java/com/thoughtworks/gocd/secretmanager/vault/VaultProvider.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/vault/VaultProvider.java
@@ -44,7 +44,8 @@ public class VaultProvider {
         VaultConfig vaultConfig = configBuilder.configFrom(secretConfig);
 
         VaultAuthenticator vaultAuthenticator = vaultAuthenticatorFactory.authenticatorFor(secretConfig);
-        Vault vault = new Vault(vaultConfig);
+        Vault vault = new Vault(vaultConfig)
+                .withRetries(secretConfig.getMaxRetries(), secretConfig.getRetryIntervalMilliseconds());
 
         String token = vaultAuthenticator.authenticate(vault, secretConfig);
 

--- a/src/main/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfig.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfig.java
@@ -42,6 +42,8 @@ public class SecretConfig {
     public static final List<String> SUPPORTED_AUTH_METHODS = asList(TOKEN_AUTH_METHOD, APPROLE_AUTH_METHOD, CERT_AUTH_METHOD);
     public static final int DEFAULT_CONNECTION_TIMEOUT = 5;
     public static final int DEFAULT_READ_TIMEOUT = 30;
+    public static final int DEFAULT_MAX_RETRIES = 0;
+    public static final int DEFAULT_RETRY_INTERVAL_MS = 100;
 
     @Expose
     @SerializedName("VaultUrl")
@@ -67,6 +69,16 @@ public class SecretConfig {
     @SerializedName("ReadTimeout")
     @Property(name = "ReadTimeout")
     private String readTimeout;
+
+    @Expose
+    @SerializedName("MaxRetries")
+    @Property(name = "MaxRetries")
+    private String maxRetries;
+
+    @Expose
+    @SerializedName("RetryIntervalMilliseconds")
+    @Property(name = "RetryIntervalMilliseconds")
+    private String retryIntervalMilliseconds;
 
     @Expose
     @SerializedName("AuthMethod")
@@ -129,6 +141,20 @@ public class SecretConfig {
         return Integer.valueOf(readTimeout);
     }
 
+    public Integer getMaxRetries() {
+        if (isBlank(maxRetries)) {
+            return DEFAULT_MAX_RETRIES;
+        }
+        return Integer.valueOf(maxRetries);
+    }
+
+    public Integer getRetryIntervalMilliseconds() {
+        if (isBlank(retryIntervalMilliseconds)) {
+            return DEFAULT_RETRY_INTERVAL_MS;
+        }
+        return Integer.valueOf(retryIntervalMilliseconds);
+    }
+
     public String getAuthMethod() {
         return authMethod;
     }
@@ -176,6 +202,8 @@ public class SecretConfig {
                 Objects.equals(nameSpace, that.nameSpace) &&
                 Objects.equals(connectionTimeout, that.connectionTimeout) &&
                 Objects.equals(readTimeout, that.readTimeout) &&
+                Objects.equals(maxRetries, that.maxRetries) &&
+                Objects.equals(retryIntervalMilliseconds, that.retryIntervalMilliseconds) &&
                 Objects.equals(authMethod, that.authMethod) &&
                 Objects.equals(token, that.token) &&
                 Objects.equals(roleId, that.roleId) &&
@@ -187,7 +215,7 @@ public class SecretConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(vaultUrl, vaultPath, nameSpace, connectionTimeout, readTimeout, authMethod, token, roleId, secretId, clientKeyPem, clientPem, serverPem);
+        return Objects.hash(vaultUrl, vaultPath, nameSpace, connectionTimeout, readTimeout, maxRetries, retryIntervalMilliseconds, authMethod, token, roleId, secretId, clientKeyPem, clientPem, serverPem);
     }
 
     public boolean isTokenAuthentication() {

--- a/src/main/resources/secrets.template.html
+++ b/src/main/resources/secrets.template.html
@@ -255,4 +255,16 @@
         <input type="number" ng-model="ReadTimeout"/>
         <span class="form_error" ng-show="GOINPUTNAME[ReadTimeout].$error.server">{{ GOINPUTNAME[ReadTimeout].$error.server }}</span>
     </div>
+
+    <div class="form_item_block">
+        <label>Max Retries:</label>
+        <input type="number" ng-model="MaxRetries"/>
+        <span class="form_error" ng-show="GOINPUTNAME[MaxRetries].$error.server">{{ GOINPUTNAME[MaxRetries].$error.server }}</span>
+    </div>
+
+    <div class="form_item_block">
+        <label>Retry Interval Milliseconds:</label>
+        <input type="number" ng-model="RetryIntervalMilliseconds"/>
+        <span class="form_error" ng-show="GOINPUTNAME[RetryIntervalMilliseconds].$error.server">{{ GOINPUTNAME[RetryIntervalMilliseconds].$error.server }}</span>
+    </div>
 </div>

--- a/src/test/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfigTest.java
+++ b/src/test/java/com/thoughtworks/gocd/secretmanager/vault/models/SecretConfigTest.java
@@ -29,6 +29,8 @@ class SecretConfigTest {
         SecretConfig secretConfig = SecretConfig.fromJSON(request);
         assertThat(secretConfig.getConnectionTimeout()).isEqualTo(5);
         assertThat(secretConfig.getReadTimeout()).isEqualTo(30);
+        assertThat(secretConfig.getMaxRetries()).isEqualTo(0);
+        assertThat(secretConfig.getRetryIntervalMilliseconds()).isEqualTo(100);
     }
 
     @Test
@@ -36,8 +38,12 @@ class SecretConfigTest {
         HashMap<String, String> request = new HashMap<>();
         request.put("ConnectionTimeout", "9");
         request.put("ReadTimeout", "50");
+        request.put("MaxRetries", "5");
+        request.put("RetryIntervalMilliseconds", "200");
         SecretConfig secretConfig = SecretConfig.fromJSON(request);
         assertThat(secretConfig.getConnectionTimeout()).isEqualTo(9);
         assertThat(secretConfig.getReadTimeout()).isEqualTo(50);
+        assertThat(secretConfig.getMaxRetries()).isEqualTo(5);
+        assertThat(secretConfig.getRetryIntervalMilliseconds()).isEqualTo(200);
     }
 }

--- a/src/test/resources/secret-config-metadata.json
+++ b/src/test/resources/secret-config-metadata.json
@@ -40,6 +40,22 @@
     }
   },
   {
+    "key": "MaxRetries",
+    "metadata": {
+      "displayName": "",
+      "required": false,
+      "secure": false
+    }
+  },
+  {
+    "key": "RetryIntervalMilliseconds",
+    "metadata": {
+      "displayName": "",
+      "required": false,
+      "secure": false
+    }
+  },
+  {
     "key": "AuthMethod",
     "metadata": {
       "displayName": "",


### PR DESCRIPTION
Context: We wanted to have the ability to control the amount of times GoCD hits Vault (via `withRetries()`) to make it more resilient to intermittent failures. Also added configurable RetryIntervalMilliseconds, as this is another arg to `withRetries()` found in vault-java-driver