### PR TITLE
Implement dynamic path specification at plugin callsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Alternatively, the configuration can be added directly to the config.xml using t
 | Field                       | Required | Description                                                                                                                                                                                                                                                        |
 |-----------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | VaultUrl                    | Yes      | The url of the Vault server instance. If no address is explicitly set, the plugin will look to the `VAULT_ADDR` environment variable.                                                                                                                              |
-| VaultPath                   | Yes      | The vault path which holds the secrets as key-value pair (e.g. `secret/gocd`)                                                                                                                                                                                      |
+| VaultPath                   | Yes      | The root vault path which holds the secrets, and should be prepended to all secret values (e.g. `secret/gocd`)                                                                                                                                                     |
 | ConnectionTimeout           | No       | The number of seconds to wait before giving up on establishing an HTTP(s) connection to the Vault server. If no openTimeout is explicitly set, then the object will look to the `VAULT_OPEN_TIMEOUT` environment variable. Defaults to `5 seconds`.                |
 | ReadTimeout                 | No       | Once connection has already been established, this is the number of seconds to wait for all data to finish downloading. If no readTimeout is explicitly set, then the object will look to the `VAULT_READ_TIMEOUT` environment variable. Defaults to `30 seconds`. |
 | ServerPem                   | No       | An X.509 certificate, in unencrypted PEM format with UTF-8 encoding to use when communicating with Vault over HTTPS                                                                                                                                                |
@@ -89,13 +89,18 @@ Alternatively, the configuration can be added directly to the config.xml using t
 | Max Retries                 | No       | Number of times to attempt to gather secrets from Vault. Defaults to `0`.                                                                                                                                                                                          |
 | Retry Interval Milliseconds | No       | Duration between retry attempts (set by `Max Retries`). Defaults to `100 milliseconds`.                                                                                                                                                                            |
 
-### Use the secret plugin in GoCD
-The complete path used to look up the secret in Vault is the concatenation of the plugin config `VaultPath`
-and the optional extra path specified in the secret key before `:`, assume the `VaultPath` given is `secret/gocd`, then:
+### Using the secret plugin in GoCD
+Since version `1.3.0`, the complete path used to look up the secret in Vault can be varied on individual secret
+retrieval, allowing a given Secret Configuration to be shared for all paths within a given root.
+
+Sub-paths can be optionally configured by prefixing the key with `subpath:`, i.e the retrieved path is the concatenation of the 
+plugin config `VaultPath` and the optional extra path specified in the secret key before `:`.
+
+Assuming the the `vault` config's root `VaultPath` is `secret/gocd`, then:
 * `{{SECRET:[vault][my_key]}}` looks up the key `my_key` in the secret at `secret/gocd`
 * `{{SECRET:[vault][my_server:my_key]}}` looks up the key `my_key` in the secret at `secret/gocd/my_server`
 * `{{SECRET:[vault][/a/b/c/d:my_key]}}` looks up the key `my_key` in the secret at `secret/gocd/a/b/c/d`
-* `{{SECRET:[vault][a:b:my_key]}}` looks up the key `a:b:my_key` in the secret at `secret/gocd`
+* `{{SECRET:[vault][a:b:my_key]}}` looks up the key `a:b:my_key` in the secret at `secret/gocd` (_multiple `:`s are ignored_)
 
 ### Building the code base
 To build the jar, run `./gradlew clean test assemble`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Alternatively, the configuration can be added directly to the config.xml using t
 | Max Retries                 | No       | Number of times to attempt to gather secrets from Vault. Defaults to `0`.                                                                                                                                                                                          |
 | Retry Interval Milliseconds | No       | Duration between retry attempts (set by `Max Retries`). Defaults to `100 milliseconds`.                                                                                                                                                                            |
 
+### Use the secret plugin in GoCD
+The complete path used to look up the secret in Vault is the concatenation of the plugin config `VaultPath`
+and the optional extra path specified in the secret key before `:`, assume the `VaultPath` given is `secret/gocd`, then:
+* `{{SECRET:[vault][my_key]}}` looks up the key `my_key` in the secret at `secret/gocd`
+* `{{SECRET:[vault][my_server:my_key]}}` looks up the key `my_key` in the secret at `secret/gocd/my_server`
+* `{{SECRET:[vault][/a/b/c/d:my_key]}}` looks up the key `my_key` in the secret at `secret/gocd/a/b/c/d`
+* `{{SECRET:[vault][a:b:my_key]}}` looks up the key `a:b:my_key` in the secret at `secret/gocd`
 
 ### Building the code base
 To build the jar, run `./gradlew clean test assemble`

--- a/src/main/java/com/thoughtworks/gocd/secretmanager/vault/SecretConfigLookupExecutor.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/vault/SecretConfigLookupExecutor.java
@@ -24,10 +24,7 @@ import com.thoughtworks.gocd.secretmanager.vault.models.Secret;
 import com.thoughtworks.gocd.secretmanager.vault.request.SecretConfigRequest;
 import io.github.jopenlibs.vault.Vault;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static cd.go.plugin.base.GsonTransformer.fromJson;
 import static cd.go.plugin.base.GsonTransformer.toJson;
@@ -45,43 +42,68 @@ class SecretConfigLookupExecutor extends LookupExecutor<SecretConfigRequest> {
         this.vaultProvider = vaultProvider;
     }
 
+
     @Override
     protected GoPluginApiResponse execute(SecretConfigRequest request) {
         try {
-            final Map<String, Map<String, String>> vaultCache = new HashMap<>();
             final List<Secret> secrets = new ArrayList<>();
             final Vault vault = vaultProvider.vaultFor(request.getConfiguration());
 
-            for (String pathKey : request.getKeys()) {
-                String[] parts = pathKey.split(":", -1);
-                String path = request.getConfiguration().getVaultPath().replaceFirst("/+$", "");
-                String key;
-                if (parts.length == 2) {
-                    String subPath = parts[0].replaceFirst("^/+", "");
-                    if (subPath.length() > 0)
-                        path += "/" + subPath;
-                    key = parts[1];
-                }
-                else { // only `a:b` is treated specially, both `a` and `a:b:c:...` are treated as normal keys
-                    key = pathKey;
-                }
+            final Map<String, Map<String, String>> vaultCache = new HashMap<>();
+            for (String optionalPathKey : request.getKeys()) {
+                PathKey resolved = PathKey.from(request.getConfiguration().getVaultPath(), optionalPathKey);
 
-                Map<String, String> secretsFromVault = vaultCache.get(path);
-                if (secretsFromVault == null) {
-                    secretsFromVault = vault.logical()
-                                            .read(path)
-                                            .getData();
-                    vaultCache.put(path, secretsFromVault);
-                }
-                if (secretsFromVault.containsKey(key)) {
-                    secrets.add(new Secret(pathKey, secretsFromVault.get(key)));
-                }
+                Map<String, String> secretsFromVault = vaultCache.computeIfAbsent(resolved.path, p -> {
+                    try {
+                        LOGGER.info("Looking up secrets from vault [{}] at resolved path [{}]",
+                                request.getConfiguration().getVaultUrl(), p);
+                        return vault.logical().read(p).getData();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+                Optional.ofNullable(secretsFromVault.get(resolved.key))
+                        .ifPresentOrElse(
+                                secret -> secrets.add(new Secret(optionalPathKey, secret)),
+                                () -> LOGGER.warn("No secret value found in vault [{}] path [{}] for key [{}]",
+                                        request.getConfiguration().getVaultUrl(), resolved.path, resolved.key)
+                        );
             }
 
             return DefaultGoPluginApiResponse.success(toJson(secrets));
         } catch (Exception e) {
             LOGGER.error("Failed to lookup secret from vault.", e);
             return DefaultGoPluginApiResponse.error(toJson(singletonMap("message", "Failed to lookup secrets from vault. See logs for more information.")));
+        }
+    }
+
+    private static class PathKey {
+        String path;
+        String key;
+        PathKey(String path, String key) {
+            this.path = path;
+            this.key = key;
+        }
+
+        static PathKey from(String commonVaultPath, String optionalPathKey) {
+            PathKey defaultPathKey = new PathKey(removeTrailingSlashes(commonVaultPath), optionalPathKey);
+            String[] parts = optionalPathKey.split(":");
+
+            // only `a:b` is treated specially, both `a` and `a:b:c:...` are treated as normal keys
+            if (parts.length == 2) {
+                // Remove leading /es from fhe first part
+                String subPath = parts[0].replaceFirst("^/+", "");
+                return subPath.isEmpty()
+                    ? new PathKey(defaultPathKey.path, parts[1])
+                    : new PathKey(defaultPathKey.path  + "/" + subPath, parts[1]);
+            }
+
+            return defaultPathKey;
+        }
+
+        private static String removeTrailingSlashes(String commonVaultPath) {
+            return commonVaultPath.replaceFirst("/+$", "");
         }
     }
 

--- a/src/main/java/com/thoughtworks/gocd/secretmanager/vault/request/SecretConfigRequest.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/vault/request/SecretConfigRequest.java
@@ -31,6 +31,7 @@ public class SecretConfigRequest {
     @SerializedName("configuration")
     private SecretConfig configuration;
 
+    /** Keys are in the form <tt>[/][optional/extra/path:]key</tt>, the path is appended to the plugin vault path */
     @Expose
     @SerializedName("keys")
     private List<String> keys;

--- a/src/main/resources/secrets.template.html
+++ b/src/main/resources/secrets.template.html
@@ -149,7 +149,7 @@
         <span class="form_error"
               ng-show="GOINPUTNAME[VaultPath].$error.server">{{ GOINPUTNAME[VaultPath].$error.server }}</span>
         <p class="form-help-content">
-            This should be the path which holds the secrets. The plugin reads secrets from a single path.
+            This is the root of the path which holds the secrets. The plugin can append an optional subpath at invocation.
         </p>
     </div>
 

--- a/src/test/java/com/thoughtworks/gocd/secretmanager/vault/SecretConfigLookupExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/secretmanager/vault/SecretConfigLookupExecutorTest.java
@@ -20,26 +20,26 @@ import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.thoughtworks.gocd.secretmanager.vault.request.SecretConfigRequest;
 import io.github.jopenlibs.vault.VaultException;
 import io.github.jopenlibs.vault.api.Logical;
-import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 @MockitoSettings
 class SecretConfigLookupExecutorTest {
+    public static final String VAULT_ROOT = "secret/gocd";
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private VaultProvider vaultProvider;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -49,42 +49,71 @@ class SecretConfigLookupExecutorTest {
 
     @BeforeEach
     void setUp() throws VaultException {
+        when(request.getConfiguration().getVaultPath()).thenReturn(VAULT_ROOT);
         when(vaultProvider.vaultFor(any()).logical()).thenReturn(logical);
-        when(logical.read("secret/gocd").getData()).thenReturn(Map.of("key1", "secret1", "key2", "secret2"));
-        when(logical.read("secret/gocd/a").getData()).thenReturn(Map.of("key1", "secret1@a", "key2", "secret2@a"));
-        when(logical.read("secret/gocd/a/b/c").getData()).thenReturn(Map.of("key1", "secret1@a/b/c", "key2", "secret2@a/b/c"));
-        when(logical.read("secret/gocd/notExists")).thenThrow(VaultException.class);
-        when(request.getConfiguration().getVaultPath()).thenReturn("secret/gocd");
     }
 
     @Test
-    void shouldReturnLookupResponse() throws JSONException {
-        final List<String> requests = Arrays.asList("key1", "key2", "key3", ":key1", "/:key2", "a:key1", "/a/b/c:key2", "a:b:c");
-        final List<String> secrets = Arrays.asList("secret1", "secret2", null, "secret1", "secret2", "secret1@a", "secret2@a/b/c", null);
-        assertThat(requests.size()).isEqualTo(secrets.size());
-        when(request.getKeys()).thenReturn(requests);
+    void shouldReturnLookupResponse() throws Exception {
+        when(logical.read(VAULT_ROOT).getData()).thenReturn(Map.of(
+                "key1", "secret1",
+                "key2", "secret2",
+                "a:b:c", "secret3",
+                "a:b:c/a:b:c", "secret4"));
+        when(logical.read(VAULT_ROOT + "/a").getData()).thenReturn(Map.of(
+                "key1", "secret1@a",
+                "key2", "secret2@a"));
+        when(logical.read(VAULT_ROOT + "/a/b/c").getData()).thenReturn(Map.of(
+                "key1", "secret1@a/b/c",
+                "key2", "secret2@a/b/c"));
+        when(logical.read(VAULT_ROOT + "/a:b:c").getData()).thenReturn(Map.of(
+                "a:b:c", "secret1@a:b:c"));
+
+        Map<String, String> requestToExpectedResult = new LinkedHashMap<>() {{
+            put("key1", "secret1");
+            put("key2", "secret2");
+            put("key3", "");
+            put("/key1", ""); // Slash not treated as part of path, as no key delimiter
+            put(":key1", "secret1");
+            put("/:key2", "secret2");
+            put("a:key1", "secret1@a");
+            put("/a/b/c:key2", "secret2@a/b/c");
+            put("/a/b/c/a:b:key", ""); // Should be treated just as key lookup for entire string
+            put("a:b:c", "secret3"); // Should be treated just as key lookup for entire string
+            put("a:b:c/a:b:c", "secret4"); // Should be treated just as key lookup for entire string
+        }};
+
+        when(request.getKeys()).thenReturn(new ArrayList<>(requestToExpectedResult.keySet()));
 
         final GoPluginApiResponse response = new SecretConfigLookupExecutor(vaultProvider)
                 .execute(request);
 
         assertThat(response.responseCode()).isEqualTo(200);
-        final String expectedResponse = IntStream.range(0, requests.size())
-                                                 .filter(i -> secrets.get(i) != null)
-                                                 .mapToObj(i -> "  {\n" +
-                                                                "    \"key\": \"" + requests.get(i) + "\",\n" +
-                                                                "    \"value\": \"" + secrets.get(i) + "\"\n" +
-                                                                "  }")
-                                                 .collect(Collectors.joining(",\n", "[\n", "]"));
+        final String expectedResponse = requestToExpectedResult.entrySet().stream()
+                .filter(e -> !e.getValue().isEmpty())
+                .map(e -> "  {\n" +
+                        "    \"key\": \"" + e.getKey() + "\",\n" +
+                        "    \"value\": \"" + e.getValue() + "\"\n" +
+                        "  }")
+                .collect(Collectors.joining(",\n", "[\n", "]"));
 
         assertEquals(expectedResponse, response.responseBody(), true);
+
+        verify(logical, times(2)).read(VAULT_ROOT);
+        verify(logical, times(2)).read(VAULT_ROOT + "/a");
+        verify(logical, times(2)).read(VAULT_ROOT + "/a/b/c");
+        verify(logical).read(VAULT_ROOT + "/a:b:c");
+
+        verifyNoMoreInteractions(logical);
     }
 
     @Test
-    void shouldErrorForInvalidPath() {
+    void shouldErrorForInvalidPath() throws VaultException {
+        when(logical.read(VAULT_ROOT + "/notExists")).thenThrow(VaultException.class);
         when(request.getKeys()).thenReturn(List.of("notExists:secret"));
 
         final GoPluginApiResponse response = new SecretConfigLookupExecutor(vaultProvider)
-                                                     .execute(request);
+                .execute(request);
 
         assertThat(response.responseCode()).isEqualTo(500);
     }

--- a/src/test/java/com/thoughtworks/gocd/secretmanager/vault/SecretConfigLookupExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/secretmanager/vault/SecretConfigLookupExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 ThoughtWorks, Inc.
+ * Copyright 2023 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,71 +16,76 @@
 
 package com.thoughtworks.gocd.secretmanager.vault;
 
-import io.github.jopenlibs.vault.Vault;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import com.thoughtworks.gocd.secretmanager.vault.request.SecretConfigRequest;
 import io.github.jopenlibs.vault.VaultException;
 import io.github.jopenlibs.vault.api.Logical;
-import io.github.jopenlibs.vault.response.LogicalResponse;
-import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import com.thoughtworks.gocd.secretmanager.vault.models.SecretConfig;
-import com.thoughtworks.gocd.secretmanager.vault.request.SecretConfigRequest;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 @MockitoSettings
 class SecretConfigLookupExecutorTest {
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private VaultProvider vaultProvider;
-    @Mock
-    private Vault vault;
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Logical logical;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private SecretConfigRequest request;
 
     @BeforeEach
     void setUp() throws VaultException {
-        when(vaultProvider.vaultFor(any())).thenReturn(vault);
-        when(vault.logical()).thenReturn(logical);
+        when(vaultProvider.vaultFor(any()).logical()).thenReturn(logical);
+        when(logical.read("secret/gocd").getData()).thenReturn(Map.of("key1", "secret1", "key2", "secret2"));
+        when(logical.read("secret/gocd/a").getData()).thenReturn(Map.of("key1", "secret1@a", "key2", "secret2@a"));
+        when(logical.read("secret/gocd/a/b/c").getData()).thenReturn(Map.of("key1", "secret1@a/b/c", "key2", "secret2@a/b/c"));
+        when(logical.read("secret/gocd/notExists")).thenThrow(VaultException.class);
+        when(request.getConfiguration().getVaultPath()).thenReturn("secret/gocd");
     }
 
     @Test
-    void shouldReturnLookupResponse() throws VaultException, JSONException {
-        final LogicalResponse logicalResponse = mock(LogicalResponse.class);
-        final SecretConfigRequest request = mock(SecretConfigRequest.class);
-        final SecretConfig secretConfig = mock(SecretConfig.class);
-        when(logical.read("/secret/gocd")).thenReturn(logicalResponse);
-        when(logicalResponse.getData()).thenReturn(new HashMap<String, String>() {{
-            put("AWS_ACCESS_KEY", "ASKDMDASDKLASDI");
-            put("AWS_SECRET_KEY", "slfjskldfjsdjflfsdfsffdadsdfsdfsdfsd;");
-        }});
-        when(request.getConfiguration()).thenReturn(secretConfig);
-        when(secretConfig.getVaultPath()).thenReturn("/secret/gocd");
-        when(request.getKeys()).thenReturn(Arrays.asList("AWS_ACCESS_KEY", "AWS_SECRET_KEY"));
+    void shouldReturnLookupResponse() throws JSONException {
+        final List<String> requests = Arrays.asList("key1", "key2", "key3", ":key1", "/:key2", "a:key1", "/a/b/c:key2", "a:b:c");
+        final List<String> secrets = Arrays.asList("secret1", "secret2", null, "secret1", "secret2", "secret1@a", "secret2@a/b/c", null);
+        assertThat(requests.size()).isEqualTo(secrets.size());
+        when(request.getKeys()).thenReturn(requests);
 
         final GoPluginApiResponse response = new SecretConfigLookupExecutor(vaultProvider)
                 .execute(request);
 
         assertThat(response.responseCode()).isEqualTo(200);
-        final String expectedResponse = "[\n" +
-                "  {\n" +
-                "    \"key\": \"AWS_ACCESS_KEY\",\n" +
-                "    \"value\": \"ASKDMDASDKLASDI\"\n" +
-                "  },\n" +
-                "  {\n" +
-                "    \"key\": \"AWS_SECRET_KEY\",\n" +
-                "    \"value\": \"slfjskldfjsdjflfsdfsffdadsdfsdfsdfsd;\"\n" +
-                "  }\n" +
-                "]";
+        final String expectedResponse = IntStream.range(0, requests.size())
+                                                 .filter(i -> secrets.get(i) != null)
+                                                 .mapToObj(i -> "  {\n" +
+                                                                "    \"key\": \"" + requests.get(i) + "\",\n" +
+                                                                "    \"value\": \"" + secrets.get(i) + "\"\n" +
+                                                                "  }")
+                                                 .collect(Collectors.joining(",\n", "[\n", "]"));
+
         assertEquals(expectedResponse, response.responseBody(), true);
+    }
+
+    @Test
+    void shouldErrorForInvalidPath() {
+        when(request.getKeys()).thenReturn(List.of("notExists:secret"));
+
+        final GoPluginApiResponse response = new SecretConfigLookupExecutor(vaultProvider)
+                                                     .execute(request);
+
+        assertThat(response.responseCode()).isEqualTo(500);
     }
 }


### PR DESCRIPTION
This PR implements a feature requested in several issues and that I need as well:
the ability to specify a secret path at the plugin callsite instead of hardcoding every secret path in a new `secretConfig`.

It does so by introducing a new `path:key` syntax in secret calls, so that the the secret path is obtained by concatenating the root path with the callsite paths.
Some examples from the PR README, assume the `VaultPath` of the `vault` `secretConfig` is `secret/gocd`, then:
* `{{SECRET:[vault][my_key]}}` looks up the key `my_key` in the secret at `secret/gocd`
* `{{SECRET:[vault][my_server:my_key]}}` looks up the key `my_key` in the secret at `secret/gocd/my_server`
* `{{SECRET:[vault][/a/b/c/d:my_key]}}` looks up the key `my_key` in the secret at `secret/gocd/a/b/c/d`
* `{{SECRET:[vault][a:b:my_key]}}` looks up the key `a:b:my_key` in the secret at `secret/gocd`

The backwards incompatibilities are minimal, only keys of the form `a:b` get treated differently than in master.

This PR contains a set of **mildly** opinionated commits, the meat is in cbb1d0893561a25e64daf7b00c8fd9b49fb714fa , but I think each of them would be of help to the codebase. It is possible to pick and choose any of them to merge though.

I've read in https://github.com/gocd/gocd-vault-secret-plugin/pull/102#issuecomment-1170214877 that the plugin is currently unmaintained and that the maintainer suggested a private fork.
I'd rather give back to upstream and not make a private fork, but if needed I can help with maintenance efforts.

The changes in this PR come with enough unit testing to ensure correctness, I've been using my plugin version in my cicd server for several days with no issue.

Thank you for the creation of this plugin, it was very helpful.

Closes: #65 #114 
~~Partially addresses: #94~~ (cherry-picked to `master` independent of this PR)