### PR TITLE
Add explicit engine version to VaultConfig

### DIFF
--- a/src/main/java/com/thoughtworks/gocd/secretmanager/vault/builders/VaultConfigBuilder.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/vault/builders/VaultConfigBuilder.java
@@ -26,6 +26,7 @@ import static com.thoughtworks.gocd.secretmanager.vault.VaultPlugin.*;
 public abstract class VaultConfigBuilder {
     public VaultConfig configFrom(SecretConfig secretConfig) throws VaultException {
         VaultConfig request = new VaultConfig()
+                .engineVersion(2)
                 .address(secretConfig.getVaultUrl())
                 .openTimeout(secretConfig.getConnectionTimeout())
                 .readTimeout(secretConfig.getReadTimeout())


### PR DESCRIPTION
This prevents the log being flooded by:
INFO: Constructing a Vault instance with no provided Engine version, defaulting to version 2.

No functional change.